### PR TITLE
Update flow on thread

### DIFF
--- a/force-app/main/default/flows/TAG_Update_NAV_unit_on_thread.flow-meta.xml
+++ b/force-app/main/default/flows/TAG_Update_NAV_unit_on_thread.flow-meta.xml
@@ -33,6 +33,14 @@
         <connector>
             <targetReference>Update_thread_NAV_unit</targetReference>
         </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Id</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>$Record.CRM_Related_Object__c</elementReference>
+            </value>
+        </filters>
         <getFirstRecordOnly>true</getFirstRecordOnly>
         <object>Contract__c</object>
         <storeOutputAutomatically>true</storeOutputAutomatically>


### PR DESCRIPTION
Updated flow that adds NAV unit from contract to thread, checks ID on contract is same as on thread to select correct contract.