### PR TITLE
Nye felt på Thread for rapportering

### DIFF
--- a/force-app/main/default/flows/TAG_Dialog_Thread_Set_to_Redaction.flow-meta.xml
+++ b/force-app/main/default/flows/TAG_Dialog_Thread_Set_to_Redaction.flow-meta.xml
@@ -1,7 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Flow xmlns="http://soap.sforce.com/2006/04/metadata"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <apiVersion>53.0</apiVersion>
+    <assignments>
+        <name>Increase_redaction_count</name>
+        <label>Increase redaction count</label>
+        <locationX>446</locationX>
+        <locationY>890</locationY>
+        <assignmentItems>
+            <assignToReference>Get_Thread.TAG_Sent_to_Redaction_Count__c</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <numberValue>1.0</numberValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Update_Thread</targetReference>
+        </connector>
+    </assignments>
     <assignments>
         <name>Set_Thread_For_Redaction</name>
         <label>Set Thread For Redaction</label>
@@ -22,7 +37,7 @@
             </value>
         </assignmentItems>
         <connector>
-            <targetReference>Update_Thread</targetReference>
+            <targetReference>Increase_redaction_count</targetReference>
         </connector>
     </assignments>
     <decisions>
@@ -79,7 +94,7 @@
         <name>Check_If_Thead_Is_Set_To_Redaction</name>
         <label>Check If Thead Is Set To Redaction</label>
         <locationX>446</locationX>
-        <locationY>998</locationY>
+        <locationY>1106</locationY>
         <defaultConnector>
             <targetReference>Error_Screen</targetReference>
         </defaultConnector>
@@ -110,16 +125,16 @@
     <dynamicChoiceSets>
         <name>ConversationNote_Cause</name>
         <dataType>Picklist</dataType>
-        <displayField xsi:nil="true" />
-        <object xsi:nil="true" />
+        <displayField xsi:nil="true"/>
+        <object xsi:nil="true"/>
         <picklistField>Cause__c</picklistField>
         <picklistObject>Conversation_Note__c</picklistObject>
     </dynamicChoiceSets>
     <dynamicChoiceSets>
         <name>Thread_Cause</name>
         <dataType>Picklist</dataType>
-        <displayField xsi:nil="true" />
-        <object xsi:nil="true" />
+        <displayField xsi:nil="true"/>
+        <object xsi:nil="true"/>
         <picklistField>Cause__c</picklistField>
         <picklistObject>Thread__c</picklistObject>
     </dynamicChoiceSets>
@@ -212,7 +227,7 @@
         <name>Update_Thread</name>
         <label>Update Thread</label>
         <locationX>446</locationX>
-        <locationY>890</locationY>
+        <locationY>998</locationY>
         <connector>
             <targetReference>Check_If_Thead_Is_Set_To_Redaction</targetReference>
         </connector>
@@ -223,7 +238,7 @@
         <name>Error_Screen</name>
         <label>Error Screen</label>
         <locationX>578</locationX>
-        <locationY>1106</locationY>
+        <locationY>1214</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>true</allowPause>
@@ -261,6 +276,7 @@
                     <stringValue>Klarte ikke å sette henvendelsen til sladding.</stringValue>
                 </value>
             </inputParameters>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
             <isRequired>true</isRequired>
             <storeOutputAutomatically>true</storeOutputAutomatically>
         </fields>
@@ -271,7 +287,7 @@
         <name>Finish_Screen</name>
         <label>Finish Screen</label>
         <locationX>314</locationX>
-        <locationY>1106</locationY>
+        <locationY>1214</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>true</allowPause>
@@ -309,6 +325,7 @@
                     <stringValue>Henvendelsen ble satt til sladding.</stringValue>
                 </value>
             </inputParameters>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
             <isRequired>true</isRequired>
             <storeOutputAutomatically>true</storeOutputAutomatically>
         </fields>
@@ -389,6 +406,7 @@
                     <stringValue>Nei</stringValue>
                 </value>
             </inputParameters>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
             <isRequired>true</isRequired>
             <storeOutputAutomatically>true</storeOutputAutomatically>
         </fields>

--- a/force-app/main/default/objects/Thread__c/fields/TAG_External_Message_Start_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Thread__c/fields/TAG_External_Message_Start_Date__c.field-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TAG_External_Message_Start_Date__c</fullName>
+    <externalId>false</externalId>
+    <label>TAG External Message Start Date</label>
+    <summarizedField>Message__c.CRM_Sent_Datetime_Formula__c</summarizedField>
+    <summaryFilterItems>
+        <field>Message__c.CRM_External_Message__c</field>
+        <operation>equals</operation>
+        <value>True</value>
+    </summaryFilterItems>
+    <summaryForeignKey>Message__c.CRM_Thread__c</summaryForeignKey>
+    <summaryOperation>min</summaryOperation>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Summary</type>
+</CustomField>

--- a/force-app/main/default/objects/Thread__c/fields/TAG_Internal_Message_Start_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Thread__c/fields/TAG_Internal_Message_Start_Date__c.field-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TAG_Internal_Message_Start_Date__c</fullName>
+    <externalId>false</externalId>
+    <label>TAG Internal Message Start Date</label>
+    <summarizedField>Message__c.CRM_Sent_Datetime_Formula__c</summarizedField>
+    <summaryFilterItems>
+        <field>Message__c.CRM_External_Message__c</field>
+        <operation>equals</operation>
+        <value>False</value>
+    </summaryFilterItems>
+    <summaryForeignKey>Message__c.CRM_Thread__c</summaryForeignKey>
+    <summaryOperation>min</summaryOperation>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Summary</type>
+</CustomField>

--- a/force-app/main/default/objects/Thread__c/fields/TAG_Sent_to_Redaction_Count__c.field-meta.xml
+++ b/force-app/main/default/objects/Thread__c/fields/TAG_Sent_to_Redaction_Count__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TAG_Sent_to_Redaction_Count__c</fullName>
+    <externalId>false</externalId>
+    <label>TAG Sent to Redaction Count</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Thread__c/fields/TAG_Started_by_External__c.field-meta.xml
+++ b/force-app/main/default/objects/Thread__c/fields/TAG_Started_by_External__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TAG_Started_by_External__c</fullName>
+    <externalId>false</externalId>
+    <formula>TAG_External_Message_Start_Date__c &lt;  TAG_Internal_Message_Start_Date__c</formula>
+    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+    <label>TAG Started by External</label>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/permissionsets/TAG_Arbeidsgiver_Dialog_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/TAG_Arbeidsgiver_Dialog_Admin.permissionset-meta.xml
@@ -78,7 +78,27 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Thread__c.TAG_External_Message_Start_Date__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Thread__c.TAG_Internal_Message_Start_Date__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Thread__c.TAG_Number_of_unread_messages_fro__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Thread__c.TAG_Sent_to_Redaction_Count__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Thread__c.TAG_Started_by_External__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>

--- a/force-app/main/default/reportTypes/Arbeidsgiver_Contract_Thread_Report.reportType-meta.xml
+++ b/force-app/main/default/reportTypes/Arbeidsgiver_Contract_Thread_Report.reportType-meta.xml
@@ -664,6 +664,16 @@
             <field>Thread__c.CRM_Type__c</field>
             <table>Contract__c</table>
         </columns>
+        <columns>
+            <checkedByDefault>false</checkedByDefault>
+            <field>Thread__c.TAG_Started_by_External__c</field>
+            <table>Contract__c</table>
+        </columns>
+        <columns>
+            <checkedByDefault>false</checkedByDefault>
+            <field>Thread__c.TAG_Sent_to_Redaction_Count__c</field>
+            <table>Contract__c</table>
+        </columns>
         <masterLabel>Thread</masterLabel>
     </sections>
 </ReportType>


### PR DESCRIPTION
Nye felt på Thread:
- _TAG_External_Message_Start_Date__c_  og _TAG_Internal_Message_Start_Date__c_ - Roll-up summary som viser timestamp med første melding fra eksterne og første fra interne. 
- _TAG_Started_by_External__c_ - Formel som sammenligner timestamps for første eksterne og interne melding, og returnerer TRUE dersom eksterne melding kom først. 
- _TAG_Sent_to_Redaction_Count__c_ - Nummerfelt som blir inkrementert med 1 hver gang flow TAG_Dialog_Thread_Set_to_Redaction markerer en dialog med sensitivt innhold.

Lagt til permission for nye felt i TAG_Arbeidsgiver_Dialog_Admin. 
Lagt til TAG_Started_by_External__c og TAG_Sent_to_Redaction_Count__c i custom rapport Arbeidsgiver_Contract_Thread_Report. 
Lagt til et element i TAG_Dialog_Thread_Set_to_Redaction som teller antal ganger tråd er satt til sladding.